### PR TITLE
feat(metrics): integrate Prometheus metrics and app metrics service

### DIFF
--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -19,7 +19,7 @@ public class AuthController : ControllerBaseCustom
     }
     [HttpPost("login")]
     [AllowAnonymous]
-    public async Task <IActionResult> Login([FromBody] LoginCommand command)
+    public async Task<IActionResult> Login([FromBody] LoginCommand command)
     {
         var response = await _mediator.Send(command);
         return Ok(response);

--- a/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -75,4 +75,10 @@ public static class ServiceCollectionExtensions
 
         return services;
     }
+
+    public static IServiceCollection AddAppMetrics(this IServiceCollection services)
+    {
+        services.AddSingleton<IAppMetricsService, AppMetricsService>();
+        return services;
+    }
 }

--- a/Middlewares/MetricsMiddleware.cs
+++ b/Middlewares/MetricsMiddleware.cs
@@ -1,0 +1,73 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using PaymentCoreServiceApi.Services;
+
+namespace PaymentCoreServiceApi.Middlewares;
+
+public class MetricsMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly IAppMetricsService _metricsService;
+
+    public MetricsMiddleware(RequestDelegate next, IAppMetricsService metricsService)
+    {
+        _next = next;
+        _metricsService = metricsService;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        
+        try
+        {
+            await _next(context);
+        }
+        finally
+        {
+            stopwatch.Stop();
+            
+            // Extract endpoint information
+            var endpoint = context.GetEndpoint();
+            if (endpoint != null)
+            {
+                var routePattern = endpoint.DisplayName ?? context.Request.Path;
+                _metricsService.RecordRequestDuration(routePattern, stopwatch.Elapsed.TotalSeconds);
+                
+                // Track API calls by controller and action
+                var controllerActionDescriptor = endpoint.Metadata.GetMetadata<ControllerActionDescriptor>();
+                if (controllerActionDescriptor != null)
+                {
+                    _metricsService.IncrementApiCalls(controllerActionDescriptor.ControllerName, controllerActionDescriptor.ActionName);
+                }
+                
+                // Track specific events based on endpoint
+                if (context.Request.Path.StartsWithSegments("/api/file/upload") && context.Response.StatusCode == 200)
+                {
+                    // Try to get content type from form data for file uploads
+                    var contentType = context.Request.Form.Files.Count > 0 
+                        ? context.Request.Form.Files[0].ContentType 
+                        : "unknown";
+                    _metricsService.IncrementFileUploads(contentType);
+                }
+                
+                // Track login attempts
+                if (context.Request.Path.StartsWithSegments("/api/auth/login"))
+                {
+                    var status = context.Response.StatusCode == 200 ? "success" : "failure";
+                    _metricsService.IncrementUserLoginAttempts(status);
+                }
+                
+                // Track messages sent
+                if (context.Request.Path.StartsWithSegments("/api/messages/send") && context.Response.StatusCode == 200)
+                {
+                    _metricsService.IncrementMessageSent();
+                }
+            }
+            else
+            {
+                _metricsService.RecordRequestDuration(context.Request.Path, stopwatch.Elapsed.TotalSeconds);
+            }
+        }
+    }
+}

--- a/PaymentCoreServiceApi.csproj
+++ b/PaymentCoreServiceApi.csproj
@@ -15,7 +15,7 @@
         <PackageReference Include="MediatR" Version="10.0.0" />
         <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.17"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.17" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.10">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -23,7 +23,8 @@
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0" />
         <PackageReference Include="Minio" Version="6.0.3" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.10" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2"/>
+        <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/README-CI-CD.md
+++ b/README-CI-CD.md
@@ -9,6 +9,7 @@ Dự án này sử dụng GitHub Actions để thực hiện CI/CD pipeline tự
 - ✅ Docker build và push
 - ✅ Automated deployment
 - ✅ Health monitoring
+- ✅ Metrics monitoring
 
 ## Workflows
 
@@ -68,6 +69,42 @@ API có health check endpoint tại `/health` để monitoring:
 - MinIO service status
 - Application health
 
+## Metrics Monitoring
+API có metrics endpoint tại `http://localhost:5050/metrics` để monitoring với Prometheus:
+- HTTP request metrics (built-in)
+- Custom application metrics:
+  - User login attempts
+  - Messages sent
+  - File uploads
+  - API call counts
+  - Request duration histograms
+
+### Available Metrics:
+- `app_user_login_attempts_total` - Tổng số lần đăng nhập (phân biệt thành công/thất bại)
+- `app_messages_sent_total` - Tổng số tin nhắn đã gửi
+- `app_file_uploads_total` - Tổng số file đã upload (phân biệt loại file)
+- `app_api_calls_total` - Tổng số API calls (phân biệt controller/action)
+- `app_request_duration_seconds` - Thời gian xử lý request (histogram)
+
+### Example Prometheus Queries:
+```
+# Rate of login attempts
+rate(app_user_login_attempts_total[5m])
+
+# Total messages sent
+app_messages_sent_total
+
+# 95th percentile of request duration
+histogram_quantile(0.95, sum(rate(app_request_duration_seconds_bucket[5m])) by (le, endpoint))
+```
+
+### Visualization with Grafana
+For easy visualization of metrics, see [Metrics Visualization Guide](docs/METRICS_VISUALIZATION.md) which includes:
+- Docker Compose setup for Prometheus and Grafana
+- Configuration files
+- Dashboard examples
+- Alerting rules
+
 ## Local Development
 
 ### Chạy với Docker Compose:
@@ -77,6 +114,9 @@ docker-compose up -d
 
 # CI environment
 docker-compose -f docker-compose.ci.yml up -d
+
+# Monitoring stack (Prometheus + Grafana)
+docker-compose -f docker-compose.monitoring.yml up -d
 ```
 
 ### Build và test local:
@@ -113,6 +153,12 @@ dotnet format --verify-no-changes
 ```bash
 # Check application health
 curl https://your-app-url/health
+```
+
+### Metrics Endpoint
+```bash
+# Check application metrics
+curl http://localhost:5050/metrics
 ```
 
 ### Logs

--- a/Services/AppMetricsService.cs
+++ b/Services/AppMetricsService.cs
@@ -1,0 +1,91 @@
+using Prometheus;
+
+namespace PaymentCoreServiceApi.Services;
+
+public interface IAppMetricsService
+{
+    void IncrementUserLoginAttempts(string status);
+    void IncrementMessageSent();
+    void RecordRequestDuration(string endpoint, double duration);
+    void IncrementFileUploads(string fileType);
+    void IncrementApiCalls(string controller, string action);
+}
+
+public class AppMetricsService : IAppMetricsService
+{
+    private readonly Counter _loginAttemptsCounter;
+    private readonly Counter _messagesSentCounter;
+    private readonly Histogram _requestDurationHistogram;
+    private readonly Counter _fileUploadsCounter;
+    private readonly Counter _apiCallsCounter;
+
+    public AppMetricsService()
+    {
+        // Counter for user login attempts
+        _loginAttemptsCounter = Metrics.CreateCounter(
+            "app_user_login_attempts_total",
+            "Total number of user login attempts",
+            new CounterConfiguration
+            {
+                LabelNames = new[] { "status" } // success, failure
+            });
+
+        // Counter for messages sent
+        _messagesSentCounter = Metrics.CreateCounter(
+            "app_messages_sent_total",
+            "Total number of messages sent");
+
+        // Histogram for request duration
+        _requestDurationHistogram = Metrics.CreateHistogram(
+            "app_request_duration_seconds",
+            "Histogram of request duration in seconds",
+            new HistogramConfiguration
+            {
+                LabelNames = new[] { "endpoint" },
+                Buckets = Histogram.ExponentialBuckets(0.01, 2, 10) // 10ms to ~10s
+            });
+
+        // Counter for file uploads
+        _fileUploadsCounter = Metrics.CreateCounter(
+            "app_file_uploads_total",
+            "Total number of file uploads",
+            new CounterConfiguration
+            {
+                LabelNames = new[] { "file_type" }
+            });
+
+        // Counter for API calls
+        _apiCallsCounter = Metrics.CreateCounter(
+            "app_api_calls_total",
+            "Total number of API calls",
+            new CounterConfiguration
+            {
+                LabelNames = new[] { "controller", "action" }
+            });
+    }
+
+    public void IncrementUserLoginAttempts(string status)
+    {
+        _loginAttemptsCounter.WithLabels(status).Inc();
+    }
+
+    public void IncrementMessageSent()
+    {
+        _messagesSentCounter.Inc();
+    }
+
+    public void RecordRequestDuration(string endpoint, double duration)
+    {
+        _requestDurationHistogram.WithLabels(endpoint).Observe(duration);
+    }
+
+    public void IncrementFileUploads(string fileType)
+    {
+        _fileUploadsCounter.WithLabels(fileType).Inc();
+    }
+
+    public void IncrementApiCalls(string controller, string action)
+    {
+        _apiCallsCounter.WithLabels(controller, action).Inc();
+    }
+}

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    networks:
+      - monitoring
+
+  grafana:
+    image: grafana/grafana-enterprise:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana-storage:/var/lib/grafana
+    networks:
+      - monitoring
+    depends_on:
+      - prometheus
+
+volumes:
+  grafana-storage:
+
+networks:
+  monitoring:
+    driver: bridge

--- a/docs/METRICS_SUMMARY.md
+++ b/docs/METRICS_SUMMARY.md
@@ -1,0 +1,98 @@
+# Metrics Monitoring Implementation Summary
+
+This document summarizes all the changes made to implement metrics monitoring in the application.
+
+## 1. Package Installation
+
+Added the `prometheus-net.AspNetCore` NuGet package to enable metrics collection and exposition.
+
+## 2. Core Configuration
+
+### Program.cs
+- Added `using Prometheus;` statement
+- Registered metrics server on port 5050
+- Added middleware for HTTP metrics collection
+- Registered custom metrics middleware
+
+## 3. Custom Metrics Service
+
+### AppMetricsService.cs
+Created a service that provides custom application metrics:
+- User login attempts counter (with success/failure labels)
+- Messages sent counter
+- File uploads counter (with file type labels)
+- API calls counter (with controller/action labels)
+- Request duration histogram (with endpoint labels)
+
+### Service Registration
+- Added `AddAppMetrics()` extension method in ServiceCollectionExtensions.cs
+- Registered the service in Program.cs
+
+## 4. Enhanced Metrics Middleware
+
+### MetricsMiddleware.cs
+Created middleware to automatically track metrics without requiring controller modifications:
+- Request duration tracking for all endpoints
+- API call counting by controller and action
+- Automatic tracking of specific events:
+  - File uploads (with content type)
+  - Login attempts (success/failure)
+  - Messages sent
+
+## 5. Clean Controller Implementation
+
+Reverted controllers to remove direct metrics service dependencies:
+- AuthController: No direct metrics dependencies
+- MessagesController: No direct metrics dependencies
+- FileController: No direct metrics dependencies
+
+All metrics are now collected automatically through middleware.
+
+## 6. Documentation
+
+### README-CI-CD.md
+Updated to include metrics monitoring information.
+
+### MetricsGuide.md
+Created comprehensive guide for using and extending metrics with middleware-based approach.
+
+## 7. Available Metrics
+
+### Built-in HTTP Metrics
+- `http_requests_received_total`
+- `http_requests_in_progress`
+- `http_request_duration_seconds`
+
+### Custom Application Metrics
+- `app_user_login_attempts_total{status="success|failure"}`
+- `app_messages_sent_total`
+- `app_file_uploads_total{file_type="content-type"}`
+- `app_api_calls_total{controller="name", action="name"}`
+- `app_request_duration_seconds{endpoint="route"}`
+
+## 8. Accessing Metrics
+
+Metrics are available at: `http://localhost:5050/metrics`
+
+## 9. Integration with Monitoring Stack
+
+### Prometheus Configuration
+```yaml
+scrape_configs:
+  - job_name: 'app-chat-api'
+    static_configs:
+      - targets: ['your-app-host:5050']
+```
+
+### Example Queries
+- Rate of login attempts: `rate(app_user_login_attempts_total[5m])`
+- Total messages sent: `app_messages_sent_total`
+- 95th percentile request duration: `histogram_quantile(0.95, sum(rate(app_request_duration_seconds_bucket[5m])) by (le, endpoint))`
+
+## 10. Extending Metrics
+
+To add new metrics:
+1. Modify AppMetricsService.cs to add new metric definitions
+2. Add corresponding methods to IAppMetricsService interface
+3. Update MetricsMiddleware.cs to track the new metrics where appropriate
+4. No controller modifications needed

--- a/docs/METRICS_VISUALIZATION.md
+++ b/docs/METRICS_VISUALIZATION.md
@@ -1,0 +1,319 @@
+# Metrics Visualization Guide
+
+This guide explains how to set up a complete monitoring stack to visualize your application metrics using Prometheus and Grafana.
+
+## Overview
+
+The monitoring stack consists of three components:
+1. **Your Application** - Exposes metrics at `http://localhost:5050/metrics`
+2. **Prometheus** - Scrapes and stores metrics
+3. **Grafana** - Visualizes metrics in dashboards
+
+## Quick Setup with Docker Compose
+
+Create a `docker-compose.monitoring.yml` file in your project root:
+
+```yaml
+version: '3.8'
+
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    networks:
+      - monitoring
+
+  grafana:
+    image: grafana/grafana-enterprise:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana-storage:/var/lib/grafana
+    networks:
+      - monitoring
+    depends_on:
+      - prometheus
+
+volumes:
+  grafana-storage:
+
+networks:
+  monitoring:
+    driver: bridge
+```
+
+## Prometheus Configuration
+
+Create a `prometheus.yml` file in your project root:
+
+```yaml
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'app-chat-api'
+    static_configs:
+      - targets: ['host.docker.internal:5050']  # For Windows Docker Desktop
+        # For Linux, use your host IP or set up proper networking
+        # targets: ['172.17.0.1:5050']
+```
+
+## Running the Monitoring Stack
+
+1. Start your application:
+```bash
+dotnet run
+```
+
+2. Start the monitoring stack using one of these methods:
+
+### Method 1: Using provided scripts
+```bash
+# Windows
+start-monitoring.bat
+
+# Linux/Mac
+./start-monitoring.sh
+```
+
+### Method 2: Manual Docker Compose
+```bash
+docker-compose -f docker-compose.monitoring.yml up -d
+```
+
+3. Access the tools:
+   - Prometheus: http://localhost:9090
+   - Grafana: http://localhost:3000 (admin/admin)
+
+## Grafana Setup
+
+### 1. Add Prometheus Data Source
+
+1. Log in to Grafana (http://localhost:3000)
+2. Go to Configuration → Data Sources
+3. Click "Add data source"
+4. Select "Prometheus"
+5. Set URL to `http://prometheus:9090`
+6. Click "Save & Test"
+
+### 2. Create Dashboards
+
+You can either import pre-built dashboards or create your own.
+
+#### Import Pre-built Dashboard
+
+1. Go to Create → Import
+2. Enter dashboard ID: 10427 (ASP.NET Core Metrics Dashboard)
+3. Select your Prometheus data source
+4. Click "Import"
+
+#### Create Custom Dashboard
+
+1. Go to Create → Dashboard
+2. Click "Add new panel"
+3. Use these queries for different panels:
+
+**Panel 1: Request Rate**
+```
+rate(http_requests_received_total[5m])
+```
+
+**Panel 2: Error Rate**
+```
+rate(http_requests_received_total{code=~"5.."}[5m])
+```
+
+**Panel 3: Request Duration (95th percentile)**
+```
+histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))
+```
+
+**Panel 4: Active Requests**
+```
+http_requests_in_progress
+```
+
+**Panel 5: Login Attempts**
+```
+rate(app_user_login_attempts_total[5m])
+```
+
+**Panel 6: File Uploads**
+```
+rate(app_file_uploads_total[5m])
+```
+
+## Useful Prometheus Queries
+
+### Application Health
+```promql
+# Request success rate
+1 - (sum(rate(http_requests_received_total{code=~"5.."}[5m])) / sum(rate(http_requests_received_total[5m])))
+
+# Average request duration
+rate(http_request_duration_seconds_sum[5m]) / rate(http_request_duration_seconds_count[5m])
+
+# Requests per second
+rate(http_requests_received_total[5m])
+```
+
+### Business Metrics
+```promql
+# Login success rate
+app_user_login_attempts_total{status="success"} / ignoring(status) app_user_login_attempts_total
+
+# File upload rate by type
+rate(app_file_uploads_total[5m])
+
+# Messages sent rate
+rate(app_messages_sent_total[5m])
+```
+
+## Alerting Rules
+
+Add these to your `prometheus.yml` for basic alerting:
+
+```yaml
+rule_files:
+  - "alerts.yml"
+
+# Add this to your prometheus.yml
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+          - alertmanager:9093
+```
+
+Create an `alerts.yml` file:
+
+```yaml
+groups:
+- name: app-alerts
+  rules:
+  - alert: HighErrorRate
+    expr: rate(http_requests_received_total{code=~"5.."}[5m]) > 0.05
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      summary: "High error rate (instance {{ $labels.instance }})"
+      description: "HTTP error rate is above 5% for more than 2 minutes\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+  - alert: HighLatency
+    expr: histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le)) > 1
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      summary: "High latency (instance {{ $labels.instance }})"
+      description: "HTTP request latency is above 1 second\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+```
+
+## Grafana Dashboard JSON
+
+Here's a sample dashboard JSON you can import:
+
+```json
+{
+  "dashboard": {
+    "id": null,
+    "title": "App Chat API Metrics",
+    "tags": ["aspnetcore", "metrics"],
+    "timezone": "browser",
+    "schemaVersion": 16,
+    "version": 0,
+    "refresh": "25s",
+    "panels": [
+      {
+        "id": 1,
+        "type": "graph",
+        "title": "Request Rate",
+        "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+        "targets": [
+          {
+            "expr": "rate(http_requests_received_total[5m])",
+            "legendFormat": "{{method}} {{code}}"
+          }
+        ]
+      },
+      {
+        "id": 2,
+        "type": "graph",
+        "title": "Request Duration (95th percentile)",
+        "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+            "legendFormat": "Duration"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Best Practices
+
+1. **Dashboard Organization**
+   - Group related metrics together
+   - Use clear, descriptive panel titles
+   - Include units in panel titles or axes
+
+2. **Alerting**
+   - Set appropriate thresholds based on historical data
+   - Use meaningful alert names and descriptions
+   - Avoid alert fatigue with proper grouping
+
+3. **Performance**
+   - Don't scrape metrics too frequently (15s is usually good)
+   - Use recording rules for expensive queries
+   - Monitor your monitoring infrastructure
+
+4. **Security**
+   - Secure your Grafana instance with proper authentication
+   - Restrict access to Prometheus and Grafana
+   - Use HTTPS in production
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Prometheus can't scrape metrics**
+   - Check if your app is running on port 5050
+   - Verify the target URL in Prometheus configuration
+   - Check firewall settings
+
+2. **No data in Grafana**
+   - Verify Prometheus data source configuration
+   - Check if Prometheus is scraping data successfully
+   - Ensure time range is set correctly in Grafana
+
+3. **High cardinality issues**
+   - Avoid using high-cardinality labels
+   - Monitor metric count in Prometheus
+   - Use recording rules to reduce cardinality
+
+### Useful Commands
+
+```bash
+# Check if metrics endpoint is accessible
+curl http://localhost:5050/metrics
+
+# Check Prometheus targets
+curl http://localhost:9090/api/v1/targets
+
+# Check Prometheus metrics
+curl http://localhost:9090/metrics
+```
+
+This setup will give you a comprehensive view of your application's performance and business metrics through an easy-to-understand web interface.

--- a/docs/MetricsGuide.md
+++ b/docs/MetricsGuide.md
@@ -1,0 +1,116 @@
+# Metrics Monitoring Guide
+
+This document explains how to use the metrics monitoring system in the application.
+
+## Overview
+
+The application uses `prometheus-net.AspNetCore` library to expose metrics for monitoring. It provides both built-in HTTP metrics and custom application metrics through a middleware-based approach.
+
+## Built-in Metrics
+
+The following HTTP metrics are automatically collected:
+
+- `http_requests_received_total` - Total HTTP requests received
+- `http_requests_in_progress` - Current HTTP requests in progress
+- `http_request_duration_seconds` - Histogram of HTTP request duration
+
+## Custom Metrics
+
+The application provides the following custom metrics through the [IAppMetricsService](file:///D:/clone_source/app_chat/app_chat_core_api/Services/AppMetricsService.cs#L9-L15):
+
+1. `app_user_login_attempts_total` - Counter for user login attempts (labeled by status: success/failure)
+2. `app_messages_sent_total` - Counter for messages sent
+3. `app_file_uploads_total` - Counter for file uploads (labeled by file_type)
+4. `app_api_calls_total` - Counter for API calls (labeled by controller and action)
+5. `app_request_duration_seconds` - Histogram for request duration (labeled by endpoint)
+
+## Middleware-Based Approach
+
+All metrics are collected automatically through the [MetricsMiddleware](file:///D:/clone_source/app_chat/app_chat_core_api/Middlewares/MetricsMiddleware.cs#L7-L76), which means:
+
+1. **No controller modifications needed** - Metrics are collected transparently
+2. **Automatic tracking** - Request duration, API calls, and specific events are tracked automatically
+3. **Centralized logic** - All metrics logic is in one place, making it easier to maintain
+
+## Adding New Metrics
+
+To add new metrics, modify the [AppMetricsService](file:///D:/clone_source/app_chat/app_chat_core_api/Services/AppMetricsService.cs#L17-L90) class:
+
+1. Add a new metric field (Counter, Gauge, Histogram, etc.)
+2. Initialize it in the constructor
+3. Add a method to interact with it
+4. Register the method in the [IAppMetricsService](file:///D:/clone_source/app_chat/app_chat_core_api/Services/AppMetricsService.cs#L9-L15) interface
+5. Update [MetricsMiddleware](file:///D:/clone_source/app_chat/app_chat_core_api/Middlewares/MetricsMiddleware.cs#L7-L76) to track the new metrics where appropriate
+
+Example:
+```csharp
+// In AppMetricsService constructor
+_customCounter = Metrics.CreateCounter(
+    "app_custom_counter_total",
+    "Description of the counter",
+    new CounterConfiguration
+    {
+        LabelNames = new[] { "label1", "label2" }
+    });
+
+// In AppMetricsService class
+public void IncrementCustomCounter(string label1, string label2)
+{
+    _customCounter.WithLabels(label1, label2).Inc();
+}
+
+// In IAppMetricsService interface
+void IncrementCustomCounter(string label1, string label2);
+```
+
+## Accessing Metrics
+
+Metrics are exposed at the `/metrics` endpoint on port 5050:
+
+```
+http://localhost:5050/metrics
+```
+
+## Prometheus Configuration
+
+To scrape metrics with Prometheus, add this to your `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: 'app-chat-api'
+    static_configs:
+      - targets: ['your-app-host:5050']
+```
+
+## Grafana Dashboard
+
+You can visualize metrics in Grafana by creating panels with Prometheus queries:
+
+- Rate of login attempts: `rate(app_user_login_attempts_total[5m])`
+- Total messages sent: `app_messages_sent_total`
+- 95th percentile request duration: `histogram_quantile(0.95, sum(rate(app_request_duration_seconds_bucket[5m])) by (le, endpoint))`
+
+## Best Practices
+
+1. Use appropriate metric types:
+   - Counter: For values that only increase (e.g., total requests)
+   - Gauge: For values that can go up and down (e.g., active users)
+   - Histogram: For distributions (e.g., request duration)
+
+2. Use labels sparingly to avoid cardinality explosion
+
+3. Avoid high-cardinality labels like user IDs or request IDs
+
+4. Use consistent naming conventions:
+   - Use base units (seconds, bytes)
+   - Use plural forms for counters (`_total` suffix)
+   - Use descriptive names
+
+5. Instrument at appropriate levels:
+   - Business logic level for meaningful metrics
+   - Avoid instrumenting every method
+
+6. Leverage middleware for cross-cutting concerns:
+   - Request duration tracking
+   - API call counting
+   - Error rate monitoring

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'app-chat-api'
+    static_configs:
+      - targets: ['host.docker.internal:5050']  # For Windows Docker Desktop
+        # For Linux, use your host IP or set up proper networking
+        # targets: ['172.17.0.1:5050']

--- a/start-monitoring.bat
+++ b/start-monitoring.bat
@@ -1,0 +1,24 @@
+@echo off
+echo Starting monitoring stack with Prometheus and Grafana...
+echo.
+
+echo Make sure your application is running on port 5050
+echo If not, start it with: dotnet run
+echo.
+
+echo Starting Docker containers...
+docker-compose -f docker-compose.monitoring.yml up -d
+
+echo.
+echo Monitoring stack started successfully!
+echo.
+echo Access the tools:
+echo   - Prometheus: http://localhost:9090
+echo   - Grafana: http://localhost:3000 (admin/admin)
+echo.
+echo Next steps:
+echo   1. Log in to Grafana
+echo   2. Add Prometheus data source (URL: http://prometheus:9090)
+echo   3. Import dashboard or create your own
+echo.
+pause

--- a/start-monitoring.sh
+++ b/start-monitoring.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+echo "Starting monitoring stack with Prometheus and Grafana..."
+echo ""
+
+echo "Make sure your application is running on port 5050"
+echo "If not, start it with: dotnet run"
+echo ""
+
+echo "Starting Docker containers..."
+docker-compose -f docker-compose.monitoring.yml up -d
+
+echo ""
+echo "Monitoring stack started successfully!"
+echo ""
+echo "Access the tools:"
+echo "  - Prometheus: http://localhost:9090"
+echo "  - Grafana: http://localhost:3000 (admin/admin)"
+echo ""
+echo "Next steps:"
+echo "  1. Log in to Grafana"
+echo "  2. Add Prometheus data source (URL: http://prometheus:9090)"
+echo "  3. Import dashboard or create your own"
+echo ""


### PR DESCRIPTION
- Add AppMetricsService and register it in dependency injection
- Integrate Prometheus metric server on port 5050
- Add middleware to expose Prometheus metrics endpoints
- Implement custom metrics middleware for application-specific metrics
- Update AuthController minor code style formatting
- Add Prometheus and related packages to project dependencies
- Enhance README with detailed metrics monitoring instructions and examples
- Configure metrics monitoring in development and CI environments via Docker Compose